### PR TITLE
Implement Load/Save function in web interface

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,6 +62,16 @@
                     </div>
                 </div>
                 <br>
+                <div class="btn-group btn-group-justified" role="group">
+                    <div class="btn-group">
+                        <button onclick="file_input.click();" id="load" class="btn btn-primary">Load</button>
+                    </div>
+                    <div class="btn-group">
+                        <button id="save" class="btn btn-primary">Save</button>
+                    </div>
+                </div>
+                <input id="file-input" type="file" name="name" style="display: none;" />
+                <br>
                 <div id="recent-instruction" class="well">The most recent instructions will be shown here when stepping.
                 </div>
                 <hr>
@@ -439,6 +449,27 @@
     <script src="index_files/bootstrap.js"></script>
     <script src="index_files/risc-v.js"></script>
     <script src="index_files/FileSaver.js"></script>
+    <script>
+        var file_input = document.createElement('input');
+        file_input.type = 'file';
+        file_input.accept = '.asc,.s';
+
+        file_input.onchange = e => { 
+            // getting a hold of the file reference
+            var file = e.target.files[0]; 
+
+            // setting up the reader
+            var reader = new FileReader();
+            reader.readAsText(file,'UTF-8');
+
+            // here we tell the reader what to do when it's done reading...
+            reader.onload = readerEvent => {
+                var content = readerEvent.target.result; // this is the content!
+                document.getElementById('code').value = content;
+                console.log( content );
+            }
+        }
+    </script>
     <script>
         $('#code').linedtextarea();
         $('.codelines').on('click', '.lineno', function () {

--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
                         <button onclick="file_input.click();" id="load" class="btn btn-primary">Load</button>
                     </div>
                     <div class="btn-group">
-                        <button id="save" class="btn btn-primary">Save</button>
+                        <button onclick="download()" id="save" class="btn btn-primary">Save</button>
                     </div>
                 </div>
                 <input id="file-input" type="file" name="name" style="display: none;" />
@@ -450,24 +450,36 @@
     <script src="index_files/risc-v.js"></script>
     <script src="index_files/FileSaver.js"></script>
     <script>
+        // File handling
         var file_input = document.createElement('input');
         file_input.type = 'file';
-        file_input.accept = '.asc,.s';
+        file_input.accept = '.asc,.s'; // only allow loading of .asc or .s files
 
         file_input.onchange = e => { 
-            // getting a hold of the file reference
             var file = e.target.files[0]; 
 
-            // setting up the reader
             var reader = new FileReader();
             reader.readAsText(file,'UTF-8');
 
-            // here we tell the reader what to do when it's done reading...
             reader.onload = readerEvent => {
-                var content = readerEvent.target.result; // this is the content!
+                var content = readerEvent.target.result;
                 document.getElementById('code').value = content;
-                console.log( content );
             }
+        }
+
+        function download(){
+            // solution from https://stackoverflow.com/questions/21479107/saving-html5-textarea-contents-to-file
+            var text = document.getElementById("code").value;
+            text = text.replace(/\n/g, "\r\n"); // retain line breaks.
+            var blob = new Blob([text], { type: "text/plain"});
+            var anchor = document.createElement("a");
+            anchor.download = "my-riscv-assembly.s";
+            anchor.href = window.URL.createObjectURL(blob);
+            anchor.target ="_blank";
+            anchor.style.display = "none";
+            document.body.appendChild(anchor);
+            anchor.click();
+            document.body.removeChild(anchor);
         }
     </script>
     <script>

--- a/index.html
+++ b/index.html
@@ -69,6 +69,18 @@
                     <div class="btn-group">
                         <button onclick="download()" id="save" class="btn btn-primary">Save</button>
                     </div>
+                    <div class="btn-group">
+                        <button id="save-extension" class="btn btn-default dropdown-toggle" data-toggle="dropdown"
+                            aria-haspopup="true" aria-expanded="false">
+                            .asc
+                            <span class="caret"></span>
+                        </button>
+                        <ul class="save-extension dropdown-menu">
+                            <li><a href="#" onclick="setFileExtension('.asc');" data-proofer-ignore="">.asc</a></li>
+                            <li><a href="#" onclick="setFileExtension('.s');" data-proofer-ignore="">.s</a></li>
+                        </ul>
+                    </div>
+
                 </div>
                 <input id="file-input" type="file" name="name" style="display: none;" />
                 <br>
@@ -467,13 +479,20 @@
             }
         }
 
+        var file_extension = '.asc';
+
+        function setFileExtension(extension) {
+            document.getElementById('save-extension').innerHTML = extension + ' <span class="caret"></span>'
+            file_extension = extension;
+        }
+
         function download(){
             // solution from https://stackoverflow.com/questions/21479107/saving-html5-textarea-contents-to-file
             var text = document.getElementById("code").value;
             text = text.replace(/\n/g, "\r\n"); // retain line breaks.
             var blob = new Blob([text], { type: "text/plain"});
             var anchor = document.createElement("a");
-            anchor.download = "my-riscv-assembly.s";
+            anchor.download = "my-riscv-assembly" + file_extension;
             anchor.href = window.URL.createObjectURL(blob);
             anchor.target ="_blank";
             anchor.style.display = "none";


### PR DESCRIPTION
Closes #1 

Per @jhibbele we want to be able to Load/Save assembly files to quickly iterate from a student's text editor. 

I have implemented this so that the file loading interface only accepts `.asc` or `.s` files (ascii or standard assembly file extension); this can be debated as necessary.

Also, as of now there is no sanity or error checking on the files. We assume they are ascii and non-malicious (bad assumption). Better file handling to come in the future... 